### PR TITLE
feat : Group 페이지 연동 기능 추가 (테스트X)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.9.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -4580,6 +4581,32 @@
       "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -12693,6 +12720,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.9.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -12,7 +12,6 @@ const ButtonWrapper = styled.div`
 `;
 
 const ButtonText = styled.span`
-  font-family: "Noto Sans KR", sans-serif;
   font-weight: 500;
   font-size: 25px;
   color: #ffffff;

--- a/src/components/Group/AllGroup.js
+++ b/src/components/Group/AllGroup.js
@@ -36,24 +36,29 @@ const GroupName = styled.div`
   font-size: 30px;
 `;
 
-const GroupMemberCount = styled.div`
+const GroupCreatedAt = styled.div`
   font-weight: bold;
-  font-size: 25px;
+  font-size: 20px;
   color: #5c5752;
 `;
 
-function AllGroup(props) {
-  const { name, memberCount } = props;
+export default function AllGroup({ key, name, description, createdAt }) {
+  const date = new Date(createdAt);
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+  const formattedDate = `${year}/${month}/${day}`;
 
   return (
-    <AllGroupContainer to="/group/detail">
+    <AllGroupContainer
+      to={{ pathname: "/group/detail", }}
+      state={{ name, description, formattedDate }}
+    >
       <GroupImage src={groupImage} />
       <GroupInfoContainer>
         <GroupName>{name}</GroupName>
-        <GroupMemberCount>{memberCount}/20</GroupMemberCount>
+        <GroupCreatedAt>{formattedDate}</GroupCreatedAt>
       </GroupInfoContainer>
     </AllGroupContainer>
   );
 }
-
-export default AllGroup;

--- a/src/components/Group/MyGroup.js
+++ b/src/components/Group/MyGroup.js
@@ -25,8 +25,7 @@ const GroupName = styled(Link)`
     }
 `;
 
-function MyGroup(props) {
-    const { name } = props;
+export default function MyGroup({ key, name }) {
 
     return (
         <MyGroupContainer>
@@ -35,5 +34,3 @@ function MyGroup(props) {
         </MyGroupContainer>
     );
 }
-
-export default MyGroup;

--- a/src/components/ManageDetail/MemberMatchInfo.js
+++ b/src/components/ManageDetail/MemberMatchInfo.js
@@ -1,9 +1,10 @@
 import React from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 import masked from "../../assets/masked.png";
 import hidden from "../../assets/hidden.png";
 
-const MemberMatchInfoContainer = styled.div`
+const MemberMatchInfoContainer = styled(Link)`
     width: 840px;
     height: 80px;
     border-radius: 50px;
@@ -34,13 +35,13 @@ const Name = styled.span`
 
 
 function MemberMatchInfo(props) {
-    const { name, isMatch, isPublic, matchName } = props;
+    const { name, isMatch, isReveal, matchName } = props;
 
     let matchMember;
 
     if(!isMatch) {
         matchMember = <Name color="#5C5752">아직 매칭되지 않았습니다</Name>;
-    } else if(isMatch && !isPublic) {
+    } else if(isMatch && !isReveal) {
         matchMember =(
             <>
                 <Name>???</Name>
@@ -57,7 +58,7 @@ function MemberMatchInfo(props) {
     }
 
     return (
-        <MemberMatchInfoContainer>
+        <MemberMatchInfoContainer to='/mypage'>
             <MemberContainer>
                 <Image src={masked} />
                 <Name>{name}</Name>

--- a/src/pages/Group.js
+++ b/src/pages/Group.js
@@ -1,25 +1,30 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
 import MyGroup from "../components/Group/MyGroup";
 import AllGroup from "../components/Group/AllGroup";
+import Button from "../components/Button";
 
 const GroupContainer = styled.div`
   position: relative;
   width: 1280px;
   height: 720px;
   margin: 0 auto;
+  padding: 10px 60px; 
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 20px;
+
   overflow: hidden;
   overflow-y: auto;
-
   scrollbar-width: none;
   -ms-overflow-style: none;
 `;
 
 const Title = styled.div`
-  position: absolute;
-  left: 60px;
-  top: ${(props) => props.top || "auto"};
   font-family: "Damion", cursive;
   font-weight: 500;
   font-size: 48px;
@@ -29,21 +34,34 @@ const Title = styled.div`
 `;
 
 const MyGroupContainer = styled.div`
-  position: absolute;
-  top: 120px;
-  left: 80px;
-  width: 70%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const MyGroupLeftContainer = styled.div`
+  width: 920px;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
   gap: 50px;
+
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  scrollbar-width: none;  
+`;
+
+const MyGroupRightContainer = styled.div`
+  width: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 const AllGroupContainer = styled.div`
-  position: absolute;
-  top: 400px;
-  left: 80px;
   width: 100%;
   display: flex;
   flex-wrap: wrap;
@@ -53,56 +71,67 @@ const AllGroupContainer = styled.div`
   gap: 25px;
 `;
 
-const GroupMakeButtonWrapper = styled.div`
-  position: absolute;
-  top: 150px;
-  right: 60px;
-  width: 180px;
-  height: 60px;
-  background: #716c67;
-  border-radius: 30px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
+export default function Group() {
+  const navigate = useNavigate();
 
-const GroupMakeButtonText = styled(Link)`
-  font-family: "Noto Sans KR", sans-serif;
-  font-weight: 500;
-  font-size: 25px;
-  color: #ffffff;
+  const [myGroups, setMyGroups] = useState([]);
+  const [allGroups, setAllGroups] = useState([]);
 
-  &:hover {
-    color: rgba(48, 48, 48, 0.5);
-  }
-`;
+  useEffect(() => {
+    const fetchGroups = async () => {
+      try {
+        const baseURL = process.env.REACT_APP_API_URL;
 
-function Group() {
+        const [myGroupsRes, allGroupsRes] = await Promise.all([
+          axios.get(`${baseURL}/group`),
+          axios.get(`${baseURL}/groups`)
+        ]);
+
+        setMyGroups(myGroupsRes.data);
+        setAllGroups(allGroupsRes.data);
+      } catch (error) {
+        console.error("그룹 데이터를 불러오는 데 실패했습니다.", error);
+      }
+    };
+
+    fetchGroups();
+  }, []);
+
+  const handleGroupMake = () => {
+    navigate("/group/make");
+  };
+
   return (
     <GroupContainer>
-      <Title top="10px">My Groups</Title>
+      <Title>My Groups</Title>
       <MyGroupContainer>
+        <MyGroupLeftContainer>
         <MyGroup name={"마니또"} />
         <MyGroup name={"마니또"} />
         <MyGroup name={"마니또"} />
         <MyGroup name={"마니또"} />
         <MyGroup name={"마니또"} />
         <MyGroup name={"마니또"} />
+        <MyGroup name={"마니또"} />
+          {/* {myGroups.map((group) => (
+            <MyGroup key={group.groupId} name={group.groupName} />
+          ))} */}
+        </MyGroupLeftContainer>
+        <MyGroupRightContainer>
+          <Button buttonText="그룹 생성" onClick={handleGroupMake} />
+        </MyGroupRightContainer>
       </MyGroupContainer>
-      <GroupMakeButtonWrapper>
-        <GroupMakeButtonText to="/group/make">그룹 생성</GroupMakeButtonText>
-      </GroupMakeButtonWrapper>
-      <Title top="300px">All Groups</Title>
+      <Title>All Groups</Title>
       <AllGroupContainer>
-        <AllGroup name={"마니또"} memberCount={10} />
-        <AllGroup name={"마니또"} memberCount={10} />
-        <AllGroup name={"마니또"} memberCount={10} />
-        <AllGroup name={"마니또"} memberCount={10} />
-        <AllGroup name={"마니또"} memberCount={10} />
-        <AllGroup name={"마니또"} memberCount={10} />
+        <AllGroup name={"마니또"} description={"테스트"} createdAt={"2025-05-23T19:20:43.861222"} />
+        <AllGroup name={"마니또"} description={"테스트"} createdAt={"2025-05-23T19:20:43.861222"} />
+        <AllGroup name={"마니또"} description={"테스트"} createdAt={"2025-05-23T19:20:43.861222"} />
+        <AllGroup name={"마니또"} description={"테스트"} createdAt={"2025-05-23T19:20:43.861222"} />
+        <AllGroup name={"마니또"} description={"테스트"} createdAt={"2025-05-23T19:20:43.861222"} />
+        {/* {allGroups.map((group) => (
+          <AllGroup key={group.groupId} name={group.groupName} description={group.description} createdAt={group.createdAt} />
+        ))} */}
       </AllGroupContainer>
     </GroupContainer>
   );
 }
-
-export default Group;

--- a/src/pages/GroupDetail.js
+++ b/src/pages/GroupDetail.js
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import groupImage from "../assets/group.png";
 
 const GroupDetailContainer = styled.div`
@@ -45,7 +45,7 @@ const GroupName = styled.div`
   font-size: 30px;
 `;
 
-const GroupMemberCount = styled.div`
+const GroupCreatedAt = styled.div`
   font-weight: bold;
   font-size: 25px;
   color: #5C5752;
@@ -79,15 +79,19 @@ const GroupJoinButtonText = styled(Link)`
 `;
 
 function GroupDetail() {
+  const location = useLocation();
+  const { name, description, formattedDate } = location.state;
+
   return (
   <GroupDetailContainer>
     <GroupCardContainer>
       <GroupImage src={groupImage} />
       <GroupInfoContainer>
-        <GroupName>마니또</GroupName>
-        <GroupMemberCount>10/20</GroupMemberCount>
+        <GroupName>{name}</GroupName>
+        <GroupCreatedAt>{formattedDate}</GroupCreatedAt>
         <GroupDescription>
-          {"그룹에 대한 설명\n어쩌구 저쩌구\n다 보이도록"}
+          {/* {"그룹에 대한 설명\n어쩌구 저쩌구\n다 보이도록"} */}
+          {description}
         </GroupDescription>
       </GroupInfoContainer>
     </GroupCardContainer>

--- a/src/pages/ManageDetail.js
+++ b/src/pages/ManageDetail.js
@@ -95,7 +95,7 @@ export default function ManageDetail({
     setIsReveal(false);
   };
   
-  const handlePublic = () => {
+  const handleReveal = () => {
     setIsReveal(true);
   };
 
@@ -120,7 +120,7 @@ export default function ManageDetail({
       </GroupDetailContainer>
       <ButtonContainer>
         <Button buttonText="마니또 매칭" onClick={handleMatch} />
-        <Button buttonText="마니또 공개" onClick={handlePublic} />
+        <Button buttonText="마니또 공개" onClick={handleReveal} />
         <Button backgroundColor="#E06A34" buttonText="그룹 삭제" />
       </ButtonContainer>
     </ManageDetailContainer>


### PR DESCRIPTION
- Group 페이지 레이아웃 수정 (My Group 가로 스크롤 추가 및 전체 레이아웃 변경)
- axios 설치 및 연동 코드 추가 (테스트X → 테스트 필요)
- 인원수 → 생성 날짜 변경으로 인한 관련 컴포넌트 수정
- GroupDetail 페이지로 이동할 때 그룹 조회 API가 없어서 클릭하는 컴포넌트의 데이터를 가져가도록 수정